### PR TITLE
Add babel as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/researchsquare/eslint-config-customer-rs#readme",
   "dependencies": {
+    "@babel/core": "^7.9.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.1.0",
@@ -30,6 +31,7 @@
     "prettier": "^1.19.1"
   },
   "peerDependencies": {
+    "@babel/core": "^7.9.0",
     "eslint": "^6.8.0",
     "prettier": "^1.19.1",
     "webpack": "^4.42.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-customer-rs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ESLint configuration for customer team",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,16 +14,6 @@ module.exports = {
         System: true,
         Promise: true,
     },
-    settings: {
-        react: {
-            version: 'detect',
-        },
-        'import/resolver': {
-            webpack: {
-                config: './webpack/config.js',
-            },
-        },
-    },
     extends: ['airbnb', 'plugin:prettier/recommended'],
     plugins: ['prettier'],
     rules: {


### PR DESCRIPTION
**Summary:**
babel-eslint depends on @babel/core. Because this was missing, yarn install was failing. This also removes Megatron-specific `settings` that was causing issues w/ linting.

**Test Plan:**
 - Tested along w/ Megatron